### PR TITLE
Support 1.25, drop support for 1.20 and 1.21

### DIFF
--- a/bin/blocked.py
+++ b/bin/blocked.py
@@ -14,7 +14,7 @@ def format_title(s):
 
 lp = check_blockers.Launchpad.login_anonymously('juju.fail', 'production', version='devel')
 
-for b in ['1.22', '1.23', '1.24', '1.25' 'master']:
+for b in ['1.22', '1.23', '1.24', '1.25', 'master']:
     uhohs = check_blockers.get_lp_bugs(lp, b)
 
     data[b] = []

--- a/bin/blocked.py
+++ b/bin/blocked.py
@@ -14,7 +14,7 @@ def format_title(s):
 
 lp = check_blockers.Launchpad.login_anonymously('juju.fail', 'production', version='devel')
 
-for b in ['1.20', '1.21', '1.22', '1.23', '1.24', 'master']:
+for b in ['1.22', '1.23', '1.24', '1.25' 'master']:
     uhohs = check_blockers.get_lp_bugs(lp, b)
 
     data[b] = []


### PR DESCRIPTION
I don't think we're supporting 1.20 or 1.21 anymore, but 1.25 exists now.
